### PR TITLE
fix extra end of line space, two places

### DIFF
--- a/xml/decoders/Zimo_Unified_software_v32_MX695_696_697V.xml
+++ b/xml/decoders/Zimo_Unified_software_v32_MX695_696_697V.xml
@@ -16,7 +16,7 @@
   <version author="Mark Waters mark16jmri@mybtinternet.com" version="1" lastUpdated="20150103"/>
   <version author="Mark Waters mark16jmri@mybtinternet.com" version="1.1" lastUpdated="20150103"/>
   <version author="Mark Waters mark16jmri@mybtinternet.com" version="1.2" lastUpdated="20160311"/>
-  <version author="Nigel Cliffe" version="1.3" lastUpdated="20161228" />  
+  <version author="Nigel Cliffe" version="1.3" lastUpdated="20161228" />
   <!-- This decoder configuration file is based on the Zimo_MX640_v9.xml                     -->
   <!-- V 1 file, dated 20090222. With the Sound tabs from Jeff Schmaltz' MX69/MX690 file.    -->
   <!--                                                                                       -->
@@ -156,7 +156,7 @@
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV1-CV99.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV100-CV152version30.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV152bit7version27.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/zimo/CV153-CV157version28.xml"/>      
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV153-CV157version28.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV158version32.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV159-CV160.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV161-CV185Servo.xml"/>


### PR DESCRIPTION
This fixes two places in the file where end-of-line characters had crept in.  Those were causing schema validation to fail.

Click the green (?) "Merge" button, then click to confirm, to merge this change onto your patch. Github will then pick it up automatically for your JMRI/JMRI#2774 PR contribution.

Thanks, and sorry for the trouble.
